### PR TITLE
firmware: reduce serial latency

### DIFF
--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -1,9 +1,11 @@
 /* multiplexed stepper motor driver
-
-  * stepper controller boards use DRV8834 or similar
-  * TI CD74HC4351 multiplexes for steps and microsteps
-  * TI SN74HC259 latches motor direction
-
+ *
+ * stepper controller boards use DRV8834 or similar
+ * TI CD74HC4351 multiplexes for steps and microsteps
+ * TI SN74HC259 latches motor direction
+ *
+ * last modified 2026-01-21
+ *
 */
 
 // pins

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -65,10 +65,11 @@ void setup() {
 }
 
 void loop() {
-  unsigned long now = millis();
+  // interval comparison avoids overflow issues
+  unsigned long waited = millis() - prev;
 
-  if (now - prev >= 5){
-    prev = now;
+  if (waited >= 5){
+    prev += waited;
     for (i = 0; i <= 5; i++){
       if (remaining[i] > 0) {
         setSelect(i);

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -72,7 +72,6 @@ void loop() {
     prev += waited;
     for (i = 0; i <= 5; i++){
       if (remaining[i] > 0) {
-        setSelect(i);
         stepMotor(i);
         --remaining[i];
       }  
@@ -123,7 +122,7 @@ void serialEvent() {  // occurs whenever new data comes in the hardware serial R
     if (digitalRead(HOME) == 0) {  // interrupt is low when blocked
       // issue instruction to move 1/4 turn counter-clockwise
       setDirection(LOW);
-      remaining[index] = 200 * u;
+      remaining[index] = 100 * u;
       // set flag to home after this movement is done
       home_after[index] = true;
     }
@@ -161,6 +160,7 @@ void setDirection(int dir) {
 }
 
 void setSelect(int index) {
+  // selection reveals HOME and DIR pins for a specific motor
   digitalWrite(S0, bitRead(index, 0));
   digitalWrite(S1, bitRead(index, 1));
   digitalWrite(S2, bitRead(index, 2));

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -122,7 +122,7 @@ void serialEvent() {  // occurs whenever new data comes in the hardware serial R
     if (digitalRead(HOME) == 0) {  // interrupt is low when blocked
       // issue instruction to move 1/4 turn counter-clockwise
       setDirection(LOW);
-      remaining[index] = abs(number);
+      remaining[index] = 200 * u;
       // set flag to home after this movement is done
       home_after[index] = true;
     }

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -70,14 +70,19 @@ void loop() {
   if (now - prev >= 5){
     prev = now;
     for (i = 0; i <= 5; i++){
-      setSelect(i);
-      if (remaining[i] > 0) stepMotor(i), --remaining[i];
+      if (remaining[i] > 0) {
+        setSelect(i);
+        stepMotor(i);
+        --remaining[i];
+      }  
       else if (home_after[i]) { // ready to home after moving off interrupt
-        remaining[i] = -1;
+        setSelect(i);
         setDirection(HIGH);
         home_after[i] = false;
+        remaining[i] = -1;
       }
       if (remaining[i] == -1) {  // motor currently homing
+        setSelect(i);
         stepMotor(i);
         // interrupt is low when blocked
         if (digitalRead(HOME) == 0) remaining[i] = 0;
@@ -115,6 +120,7 @@ void serialEvent() {  // occurs whenever new data comes in the hardware serial R
     //   is already at the interrupt
     setSelect(index);
     if (digitalRead(HOME) == 0) {  // interrupt is low when blocked
+      // issue instruction to move 1/4 turn counter-clockwise
       setDirection(LOW);
       remaining[index] = abs(number);
       // set flag to home after this movement is done

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -123,8 +123,8 @@ void serialEvent() {  // occurs whenever new data comes in the hardware serial R
     // if interrupt is not blocked, we set remaining to -1, a special code for home
     else {
       setDirection(HIGH);
+      remaining[index] = -1;
     }
-    remaining[index] = -1;
   }
   else if (*code == 'Q') {  // query motor status
     setSelect(index);

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -65,7 +65,8 @@ void setup() {
 }
 
 void loop() {
-  now = millis();
+  unsigned long now = millis();
+
   if (now - prev >= 5){
     prev = now;
     for (i = 0; i <= 5; i++){

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -32,6 +32,7 @@ char c_number = '0';
 int index = 0;
 int number = 0;
 int remaining[6];
+unsigned long prev = 0;
 
 void setup() {
   // initialize pins
@@ -59,23 +60,25 @@ void setup() {
   setM();
   // initialize direction
   digitalWrite(D, LOW);
-  // initiate serial
   Serial.begin(57600);
   while (!Serial);  // do nothing, waiting for port to connect
 }
 
 void loop() {
-  for (i = 0; i <= 5; i++){
-    setSelect(i);
-    if (remaining[i] > 0) stepMotor(i), --remaining[i];
-    if (remaining[i] == -1) {  // motor currently homing
-      stepMotor(i);
-      // interrupt is low when blocked
-      if (digitalRead(HOME) == 0) remaining[i] = 0;
+  now = millis();
+  if (now - prev >= 5){
+    prev = now;
+    for (i = 0; i <= 5; i++){
+      setSelect(i);
+      if (remaining[i] > 0) stepMotor(i), --remaining[i];
+      }
+      if (remaining[i] == -1) {  // motor currently homing
+        stepMotor(i);
+        // interrupt is low when blocked
+        if (digitalRead(HOME) == 0) remaining[i] = 0;
+      }
     }
   }
-  delay(5);
-  //Serial.println(millis());
 }
 
 void serialEvent() {  // occurs whenever new data comes in the hardware serial RX

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -1,10 +1,10 @@
-/* stepper motor driver
- *
- * contributers:
- *   Blaise Thompson - blaise@untzag.com
- *
- * last modified 2016-10-13
- */
+/* multiplexed stepper motor driver
+
+  * stepper controller boards use DRV8834 or similar
+  * TI CD74HC4351 multiplexes for steps and microsteps
+  * TI SN74HC259 latches motor direction
+
+*/
 
 // pins
 int S0 = A0;
@@ -21,7 +21,6 @@ int motors[6] = {2, 3, 4, 5, 6, 7};
 
 // variables
 int i = 0;  // for looping
-int num = 0;
 int u = 1;  // microstepping amount
 #define INPUT_SIZE 100  // TODO: make this a reasonable value
 #define sep " "


### PR DESCRIPTION
Untested on hardware atm

* uses millis instead of delay in main loop, which should make serial communication faster
* setSelect is only called when accessing HOME/DIR attrs (drastically less pin writing).
* replaced homing backup instruction (a blocking loop) with a procedure built upon a flag in the main loop
* resolves #2 

# Tasks:

- [x] tests on actual motors (done; used fs table filter wheels